### PR TITLE
Update heart_broken glyph for Nerd 3.0+

### DIFF
--- a/gruvbox.zsh-theme
+++ b/gruvbox.zsh-theme
@@ -260,7 +260,7 @@ prompt_virtualenv() {
 prompt_status() {
   local -a symbols
 
-  [[ $RETVAL -ne 0 ]] && symbols+="%{%F{1}%}\uf7d3" #
+  [[ $RETVAL -ne 0 ]] && symbols+="%{%F{1}%}\Uf02d4" #󰋔
   [[ $UID -eq 0 ]] && symbols+="%{%F{11}%}\ue77a" #
   [[ $(jobs -l | wc -l) -gt 0 ]] && symbols+="%{%F{15}%}\ufb36" #󰘷
 


### PR DESCRIPTION
The heart_broken glyph broke with Nerd Fonts 3.0 and above. See https://www.nerdfonts.com/releases for more info.